### PR TITLE
docs: update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Documentation can be found here: https://docs.phylum.io/docs/policy
+Documentation can be found here: <https://docs.phylum.io/knowledge_base/policy>


### PR DESCRIPTION
NOTE: This PR is not meant to be merged until after the docs.phylum.io page is cutover from being hosted on README.com to GitHub Pages.