### PR TITLE
add action for pushing policies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ jobs:
   lint:
     name: Lint policies
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -30,6 +32,8 @@ jobs:
   deploy:
     name: Deploy policies
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: lint
     if: success() && github.ref == 'refs/heads/main'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,10 @@
-name: Lint policies
-
 on:
   push:
   workflow_dispatch:
 
 jobs:
   lint:
+    name: Lint policies
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,3 +26,15 @@ jobs:
       - name: Regal Lint
         if: ${{ !cancelled() }}
         run: regal lint --format github .
+
+  deploy:
+    name: Deploy policies
+    runs-on: ubuntu-latest
+    needs: lint
+    if: success() && github.ref == 'refs/heads/main'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Upload
+        run: .github/workflows/upload.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,5 +42,5 @@ jobs:
 
       - name: Upload
         env:
-          PHYLUM_TOKEN: ${{ secrets.PHYLUM_TOKEN }}
+          PHYLUM_TOKEN: ${{ secrets.PHYLUM_POLICY_TOKEN }}
         run: python3 .github/workflows/upload.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,4 +41,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Upload
+        env:
+          PHYLUM_TOKEN: ${{ secrets.PHYLUM_TOKEN }}
         run: .github/workflows/upload.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Upload
         env:
           PHYLUM_TOKEN: ${{ secrets.PHYLUM_TOKEN }}
-        run: .github/workflows/upload.py
+        run: python3 .github/workflows/upload.py

--- a/.github/workflows/upload.py
+++ b/.github/workflows/upload.py
@@ -16,7 +16,7 @@ import uuid
 GROUP_NAME = None
 token = os.environ["PHYLUM_TOKEN"]
 version = os.environ.get("GITHUB_SHA", None)
-BASE_ADDRESS = "https://api.staging.phylum.io/api/"
+BASE_ADDRESS = "https://api.phylum.io/api/"
 
 # Build a multipart form body.
 boundary = uuid.uuid4().hex

--- a/.github/workflows/upload.py
+++ b/.github/workflows/upload.py
@@ -2,6 +2,7 @@
 Script to upload a set of policy files to Phylum.
 """
 
+import contextlib
 import io
 import json
 import os
@@ -11,6 +12,7 @@ from urllib.error import HTTPError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
 import uuid
+import sys
 
 # Set the group name if you are uploading policies for a group.
 GROUP_NAME = None
@@ -64,11 +66,9 @@ try:
         pass
 except HTTPError as error:
     response = error.read().decode("utf8", errors="replace")
-    try:
+    with contextlib.suppress(json.JSONDecodeError):
         # Phylum's API returns JSON error descriptions.
         # If that's what we got, reformat it to be more readable.
         response = json.dumps(json.loads(response), indent=2)
-    except json.JSONDecodeError:
-        pass
     print(response)
-    exit(1)
+    sys.exit(1)

--- a/.github/workflows/upload.py
+++ b/.github/workflows/upload.py
@@ -1,0 +1,74 @@
+"""
+Script to upload a set of policy files to Phylum.
+"""
+
+import io
+import json
+import os
+from pathlib import Path
+import shutil
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+import uuid
+
+# Set the group name if you are uploading policies for a group.
+GROUP_NAME = None
+token = os.environ["PHYLUM_TOKEN"]
+version = os.environ.get("GITHUB_SHA", None)
+BASE_ADDRESS = "https://api.staging.phylum.io/api/"
+
+# Build a multipart form body.
+boundary = uuid.uuid4().hex
+body = io.BytesIO()
+
+for file in Path.cwd().glob("*.rego"):
+    body.write(f"--{boundary}\r\n".encode("ascii"))
+    body.write(
+        f'Content-Disposition: form-data; name="{file.stem}"; filename="{file.name}"\r\n'.encode(
+            "ascii"
+        )
+    )
+    body.write(b"Content-Type: text/plain\r\n\r\n")
+
+    with file.open("rb") as f:
+        shutil.copyfileobj(f, body)
+
+    body.write(b"\r\n")
+
+body.write(f"--{boundary}--".encode("ascii"))
+
+# Send the request.
+if GROUP_NAME is None:
+    endpoint = f"{BASE_ADDRESS}v0/available-policies"
+else:
+    endpoint = (
+        f"{BASE_ADDRESS}v0/groups/{quote(GROUP_NAME, safe='')}/available-policies"
+    )
+
+if version is not None:
+    endpoint = f"{endpoint}?version={quote(version, safe='')}"
+
+request = Request(
+    endpoint,
+    data=body.getbuffer(),
+    headers={
+        "Authorization": f"Bearer {token}",
+        "Content-Type": f'multipart/form-data;boundary="{boundary}"',
+    },
+    method="PUT",
+)
+
+try:
+    with urlopen(request) as f:
+        pass
+except HTTPError as error:
+    response = error.read().decode("utf8", errors="replace")
+    try:
+        # Phylum's API returns JSON error descriptions.
+        # If that's what we got, reformat it to be more readable.
+        response = json.dumps(json.loads(response), indent=2)
+    except json.JSONDecodeError:
+        pass
+    print(response)
+    exit(1)


### PR DESCRIPTION
This PR adds a Python script to the GitHub workflow that publishes the policies to prod when building the main branch.

Users may also find this script useful if they have their own group policies in a repository.