### PR TITLE
Add All Crit and Sus IP regos

### DIFF
--- a/all_crit_no_vuln.rego
+++ b/all_crit_no_vuln.rego
@@ -1,0 +1,17 @@
+# METADATA
+# title: All Critical (except Software Vulnerability)
+# description: |
+#    Blocks Critical issues (except software vulnerabilities)
+package policy.v1
+
+import data.phylum.domain
+import data.phylum.level
+import rego.v1
+
+# METADATA
+# title: Critical issue
+deny contains issue if {
+	some issue in data.issues
+	issue.domain != domain.VULNERABILITY
+	issue.severity == level.CRITICAL
+}

--- a/copyleft_license.rego
+++ b/copyleft_license.rego
@@ -1,0 +1,14 @@
+# METADATA
+# title: Copyleft license
+# description: |
+#    Block packages that have a copyleft license
+package policy.v1
+
+import rego.v1
+
+# METADATA
+# title: Copyleft license
+deny contains issue if {
+	some issue in data.issues
+	issue.tag == "IL0050"
+}

--- a/suspicious_ip.rego
+++ b/suspicious_ip.rego
@@ -1,0 +1,14 @@
+# METADATA
+# title: Suspicious IP References
+# description: |
+#    Block packages containing suspicious IP addresses
+package policy.v1
+
+import rego.v1
+
+# METADATA
+# title: Suspicious IP reference
+deny contains issue if {
+	some issue in data.issues
+	issue.tag == "CM0001"
+}


### PR DESCRIPTION
- Add new rego to surface rejections for all `Critical` issues in any domain except `VULN`
- Add new rego to surface rejections for the suspicious IP rule
- Add new rego to surface rejections for copyleft licenses