### PR TITLE
include CM1002

### DIFF
--- a/confirmed_malicious.rego
+++ b/confirmed_malicious.rego
@@ -17,14 +17,14 @@ deny contains issue if {
 # title: Verified malware
 deny contains issue if {
 	some issue in data.issues
-	issue.tag in {"CM0037", "CM1002"}
+	issue.tag in {"CM0038", "CM1002"}
 }
 
 # METADATA
 # title: Known-bad compiled binary
 deny contains issue if {
 	some issue in data.issues
-	issue.tag == "CM0038"
+	issue.tag == "CM0037"
 }
 
 # METADATA

--- a/confirmed_malicious.rego
+++ b/confirmed_malicious.rego
@@ -17,7 +17,7 @@ deny contains issue if {
 # title: Verified malware
 deny contains issue if {
 	some issue in data.issues
-	issue.tag == "CM0037"
+	issue.tag in {"CM0037", "CM1002"}
 }
 
 # METADATA


### PR DESCRIPTION
Since the latest release of the API, if a package is marked as malware by the [OSSF MAL database](https://github.com/ossf/malicious-packages/tree/main/osv/malicious) we add an issue with a CM1002 tag. This has roughly the same meaning as CM0037, our internal tag for when we've marked something as malware, so I put it into the same rule.